### PR TITLE
Flip deploy order

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -51,7 +51,7 @@ deployment:
         :
           timeout: 7200
       - cd /home/ubuntu/image-builder
-      - ansible  -vvvv -i "10.92.1.31,10.92.1.32,10.92.1.30,10.92.1.27" -a "sudo docker pull eastus-artifactory.azure.rmsonecloud.net:6001/buildbox:latest" all
+      - ansible  -v -i "10.92.1.31,10.92.1.32,10.92.1.30,10.92.1.27" -a "sudo docker pull eastus-artifactory.azure.rmsonecloud.net:6001/buildbox:latest" all
     all:
       branch: /.*?/
       commands:

--- a/circle.yml
+++ b/circle.yml
@@ -38,10 +38,6 @@ test:
     - sudo -E /opt/circleci/.pyenv/shims/python -m pytest tests/test_docker_image.py
 
 deployment:
-  all:
-    branch: /.*?/
-    commands:
-      - make push-$BUILD_TARGET
   production:
     branch: rms-master
     commands:
@@ -56,3 +52,7 @@ deployment:
           timeout: 7200
       - cd /home/ubuntu/image-builder
       - ansible  -vvvv -i "10.92.1.31,10.92.1.32,10.92.1.30,10.92.1.27" -a "sudo docker pull eastus-artifactory.azure.rmsonecloud.net:6001/buildbox:latest" all
+    all:
+      branch: /.*?/
+      commands:
+        - make push-$BUILD_TARGET


### PR DESCRIPTION
`rms-master` branch was getting caught in the `all` deployment step due to the regex and thus not tagging/pushing out to the nodes properly!